### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -6,14 +6,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]     # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8]  # [3.6, 3.7, 3.9, pypy3]
+        python-version: [3.8, 3.9]  # [3.6, 3.7, pypy3]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install black codespell flake8 isort pytest
+      - run: pip install black codespell flake8 isort pytest wheel
       - run: black --check . || true
       - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8]  # [3.6, 3.7, 3.9, pypy3]
+        python-version: [3.9]  # [3.6, 3.7, 3.8, pypy3]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -18,5 +18,5 @@ jobs:
       - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --profile black . || true
-      - run: pip install -r requirements.txt
+      - run: pip install -r requirements.txt || true
       - run: pytest . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]     # [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest]     # [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.8, 3.9]  # [3.6, 3.7, pypy3]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest]     # [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.9]  # [3.6, 3.7, 3.8, pypy3]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9]  # [3.6, 3.7, 3.8, pypy3]
+        python-version: [3.8]  # [3.6, 3.7, 3.9, pypy3]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -15,8 +15,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install black codespell flake8 isort pytest
       - run: black --check . || true
-      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --profile black . || true
-      - run: pip install -r requirements.txt || true
+      - run: pip install -r requirements.txt
       - run: pytest . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,22 @@
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]    # [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.9]  # [3.6, 3.7, 3.8, pypy3]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install black codespell flake8 isort pytest
+      - run: black --check . || true
+      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      - run: isort --profile black . || true
+      - run: pip install -r requirements.txt || true
+      - run: pytest . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]     # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9]  # [3.6, 3.7, pypy3]
+        python-version: [3.8]  # [3.6, 3.7, 3.9, pypy3]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]     # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9]  # [3.6, 3.7, 3.8, pypy3]
+        python-version: [3.8]  # [3.6, 3.7, 3.9, pypy3]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/pathfind-visualiser/assets/algorithms.py
+++ b/pathfind-visualiser/assets/algorithms.py
@@ -180,7 +180,7 @@ def depth_first_search(draw, grid, start, end):
     """
     Searches every possible path from the starting node and returns a route.
 
-    Depth first search will be extremely innacurate at giving short paths in open mazes.
+    Depth first search will be extremely inaccurate at giving short paths in open mazes.
     This is because it searches nodes in order of top, right, bottom, left so it will always
     expand go to the left if possible (LIFO), often returning very longwinded routes to get to the end node.
     Hence, this does not ensure the shortest path.

--- a/pathfind-visualiser/main.py
+++ b/pathfind-visualiser/main.py
@@ -46,7 +46,7 @@ def outline_rect(window, size, x, y, width, height):
 def draw_background(window, size, x, y, width, height):
     """Draws a frame to contain other ui elements. Has a thin black border."""
     bg_colour = BG2
-    # Draws outline arround background
+    # Draws outline around background
     outline_rect(window, size, x, y, width, height)
     # Draws background surface
     pygame.draw.rect(window, bg_colour, (x,


### PR DESCRIPTION
Output: https://github.com/cclauss/pathfind-visualiser/actions

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.